### PR TITLE
Added functionality to detach all uprobes for a binary

### DIFF
--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -529,6 +529,34 @@ StatusTuple BPF::detach_uprobe(const std::string& binary_path,
   return StatusTuple::OK();
 }
 
+// Detach all uprobes associated with the given binary path.
+// This function cleans up all matching uprobes without checking if the binary file exists.
+// It simply matches the sanitized binary path in the event names and detaches them.
+StatusTuple BPF::detach_all_uprobes_for_binary(const std::string& binary_path) {
+  bool has_error = false;
+  std::string error_msg;
+  std::vector<std::string> to_detach;
+
+  // Sanitize the binary path as used in event names
+  std::string sanitized_path = sanitize_str(binary_path, &BPF::uprobe_path_validator);
+  // Find all uprobes for this binary
+  for (auto& it : uprobes_) {
+    if (it.first.find(sanitized_path) != std::string::npos) {
+      auto res = detach_uprobe_event(it.first, it.second);
+      if (!res.ok()) {
+        error_msg += "Failed to detach uprobe event " + it.first + ": ";
+        error_msg += res.msg() + "\n";
+        has_error = true;
+      }
+      uprobes_.erase(it.first);
+    }
+  }
+  if (has_error)
+    return StatusTuple(-1, error_msg);
+  else
+    return StatusTuple::OK();
+}
+
 StatusTuple BPF::detach_usdt_without_validation(const USDT& u, pid_t pid) {
   auto& probe = *static_cast<::USDT::Probe*>(u.probe_.get());
   bool failed = false;

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -152,6 +152,7 @@ class BPF {
                             bpf_probe_attach_type attach_type = BPF_PROBE_ENTRY,
                             pid_t pid = -1,
                             uint64_t symbol_offset = 0);
+  StatusTuple detach_all_uprobes_for_binary(const std::string& binary_path);
   StatusTuple attach_usdt(const USDT& usdt, pid_t pid = -1);
   StatusTuple attach_usdt_all();
   StatusTuple detach_usdt(const USDT& usdt, pid_t pid = -1);


### PR DESCRIPTION
Added a new method in BCC

`StatusTuple BPF::detach_all_uprobes_for_binary(const std::string& binary_path)`

This method detaches all uprobe probes that are associated with the given binary path. It works by matching the sanitized binary path against the event names of all currently attached uprobes, and detaches any that match. Importantly, this function does not check if the binary file still exists on disk; it simply removes all matching uprobes from the internal tracking and from the kernel.

This is useful for cleaning up probes that may otherwise remain attached if the binary is deleted or moved, or if you want to forcibly remove all uprobes for a specific binary regardless of its current presence on the filesystem.

Use Case
Automatic Cleanup When a Binary is Deleted:
If a monitored binary is removed from the filesystem, any uprobes attached to it will remain active in the kernel unless explicitly detached. This function allows you to clean up all such probes, preventing resource (fd) leaks and potential errors.

Bulk Detachment:
When updating or replacing a binary, you may want to remove all associated uprobes before re-attaching new ones. This function provides a simple way to do so without needing to track individual probe details.

Example:
Suppose you are tracing a user-space binary /proc//exe and that binary is deleted still you can call:

`bpf.detach_all_uprobes_for_binary("/proc/<program-pid>/exe");`

This will remove all uprobes associated with stoped program-pid , even if the file no longer exists, ensuring no stale probes are left behind.

With this functionality https://github.com/iovisor/bcc/issues/4843 will fixed